### PR TITLE
Switch from GitHub Package Regitry to Docker Hub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Docker run
         run: docker run --entrypoint cdk image --version
 
-  # Push image to GitHub Package Registry.
+  # Push image to Docker Hub.
   # See also https://docs.docker.com/docker-hub/builds/
   push:
     # Ensure test job passes before pushing image.
@@ -52,11 +52,11 @@ jobs:
         run: docker build . --file Dockerfile --tag image
 
       - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u scottbrenner --password-stdin
 
       - name: Push image
         run: |
-          IMAGE_ID=docker.pkg.github.com/scottbrenner/aws-cdk-action/$IMAGE_NAME
+          IMAGE_ID=scottbrenner/$IMAGE_NAME
 
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
     - name: CDK Synth
-      uses: docker://docker.pkg.github.com/scottbrenner/aws-cdk-action/aws-cdk-action:latest
+      uses: docker://scottbrenner/aws-cdk-action:latest
       with:
         args: synth
       env:


### PR DESCRIPTION
Changing the GitHub Actions workflow to push the image to Docker Hub and reference it in the example workflow.