### PR TITLE
fix(Dockerfile): Pin alpine:3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.13
 
 LABEL name="aws-cdk-action"
 LABEL repository="https://github.com/ScottBrenner/aws-cdk-action"


### PR DESCRIPTION
Closes https://github.com/ScottBrenner/aws-cdk-action/issues/23 ?

Following discussion in https://github.com/aws/aws-cdk/issues/15179#issuecomment-864033710 ➡️ https://github.com/youyo/aws-cdk-github-actions/issues/36#issuecomment-864131884 there appears to be an issue with `alpine:3`, not present in `alpine:3.13`.