### PR TITLE
CDK for Go requires bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL "com.github.actions.color"="yellow"
 
 LABEL "maintainer"="Scott Brenner <scott@scottbrenner.me>"
 
-RUN apk --no-cache add nodejs npm python3 py3-pip git make musl-dev go
+RUN apk --no-cache add nodejs npm python3 py3-pip git make musl-dev go bash
 RUN npm install -g aws-cdk
 RUN pip3 install aws-cdk-lib --break-system-packages
 


### PR DESCRIPTION
Bundling of Go code doesn't work without bash as required by the CDK.