### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
   # Run tests.
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/ScottBrenner/aws-cdk-action/security/code-scanning/1](https://github.com/ScottBrenner/aws-cdk-action/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `test` job. Since the job only performs local operations (e.g., Docker build and run), it does not require any write permissions. The minimal required permission is `contents: read`, which allows the job to read repository contents if needed. This change ensures that the job operates with the least privilege necessary.

The `permissions` block will be added directly under the `test` job definition in the `.github/workflows/main.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
